### PR TITLE
Risen 3 mesh reader

### DIFF
--- a/Rimy3D/source/batchdialog.cpp
+++ b/Rimy3D/source/batchdialog.cpp
@@ -44,7 +44,7 @@ BatchDialog::BatchDialog( void ) :
     m_bAborted( false )
 {
     m_pUi->setupUi( this );
-    m_pUi->cobOutputFileFormat->addItems( QStringList() << "Baltram's 3D format (*.3db)" << "3D Studio Mesh (*.3ds)" << "Wavefront OBJ format (*.obj)" << "3ds Max ASCII Scene (*.ase)" << "Gothic ASCII Scene (*.asc)" << "Gothic 3 Mesh (*.xcmsh)" << "Gothic 3 Motion Actor (*.xact)" << "Gothic 3 LOD Mesh (*.xlmsh)" << "Gothic 3 Collision Mesh (*.xnvmsh)" << "Risen Mesh (*._xmsh)" << "Risen Motion Actor (*._xmac)" << "Risen Collision Mesh (*._xcom)" );
+    m_pUi->cobOutputFileFormat->addItems( QStringList() << "Baltram's 3D format (*.3db)" << "3D Studio Mesh (*.3ds)" << "Wavefront OBJ format (*.obj)" << "3ds Max ASCII Scene (*.ase)" << "Gothic ASCII Scene (*.asc)" << "Gothic 3 Mesh (*.xcmsh)" << "Gothic 3 Motion Actor (*.xact)" << "Gothic 3 LOD Mesh (*.xlmsh)" << "Gothic 3 Collision Mesh (*.xnvmsh)" << "Risen Mesh (*._xmsh)" << "Risen Motion Actor (*._xmac)" << "Risen Collision Mesh (*._xcom)" << "Risen 3 Mesh (*.r3msh)" );
     qRegisterMetaType< Rimy3D::EMessage >( "Rimy3D::EMessage" );
     connect( Rimy3D::getInstance(), SIGNAL( message( QString const &, Rimy3D::EMessage ) ), this, SLOT( onMessage( QString const &, Rimy3D::EMessage ) ) );
     connect( Rimy3D::getInstance(), SIGNAL( settingsSaving( QSettings & ) ), this, SLOT( saveSettings( QSettings & ) ) );
@@ -68,7 +68,7 @@ void BatchDialog::addFilesFromDirectory( QDir const & a_Dir )
 {
     bool bSortingEnabled = m_pUi->lwSourceFiles->isSortingEnabled();
     m_pUi->lwSourceFiles->setSortingEnabled( false );
-    QFileInfoList arrFiles = a_Dir.entryInfoList( QStringList() << "*.3db" << "*.3ds" << "*.obj" << "*.ase" << "*.asc" << "*.xcmsh" << "*.xact" << "*.xlmsh" << "*.xnvmsh" << "*._xmsh" << "*._xmac" << "*._xcom", QDir::Files | QDir::Readable );
+    QFileInfoList arrFiles = a_Dir.entryInfoList( QStringList() << "*.3db" << "*.3ds" << "*.obj" << "*.ase" << "*.asc" << "*.xcmsh" << "*.xact" << "*.xlmsh" << "*.xnvmsh" << "*._xmsh" << "*._xmac" << "*._xcom" << "*.r3msh", QDir::Files | QDir::Readable );
     for ( int i = 0, ie = arrFiles.count(); i != ie; ++i )
         m_pUi->lwSourceFiles->addItem( QDir::toNativeSeparators( arrFiles.at( i ).absoluteFilePath() ) );
     if ( m_pUi->cbIncludeSubdirs->isChecked() )

--- a/Rimy3D/source/mainwindow.cpp
+++ b/Rimy3D/source/mainwindow.cpp
@@ -18,7 +18,7 @@ MainWindow & MainWindow::getInstance( void )
 QString MainWindow::getOpenFilter( void )
 {
     QString strResult = tr( "All files" );
-    strResult.append( " (*.3ds *.obj *.3db *.gmax *.ase *.asc *.xcmsh *.xlmsh *.xnvmsh *.xact *._xmac *._xmsh *._xcom);;"
+    strResult.append( " (*.3ds *.obj *.3db *.gmax *.ase *.asc *.xcmsh *.xlmsh *.xnvmsh *.xact *._xmac *._xmsh *._xcom *.r3msh);;"
                       "Baltram's 3D format (*.3db);;"
                       "3D Studio Mesh (*.3ds);;"
                       "Wavefront OBJ format (*.obj);;"
@@ -31,7 +31,8 @@ QString MainWindow::getOpenFilter( void )
                       "Gothic 3 Collision Mesh (*.xnvmsh);;"
                       "Risen Mesh (*._xmsh);;"
                       "Risen Motion Actor (*._xmac);;"
-                      "Risen Collision Mesh (*._xcom);;" );
+                      "Risen Collision Mesh (*._xcom);;"
+                      "Risen 3 Mesh (*.r3msh);;" );
     return strResult;
 }
 

--- a/Rimy3D/source/sceneinfo.cpp
+++ b/Rimy3D/source/sceneinfo.cpp
@@ -244,6 +244,10 @@ bool SceneInfo::openSceneFile( QString a_strFilePath, bool a_bMerge )
     {
         enuResult = mCXnvmshReader::ReadXnvmshFileData( sceneNew, streamIn );
     }
+    else if ( strExt == "r3msh" )
+    {
+        enuResult = mCR3mshReader::ReadR3mshFileData( sceneNew, streamIn );
+    }
     else
     {
         Rimy3D::showError( tr( "Unknown file type: \".%1\"" ).arg( strExt ), Rimy3D::applicationName() );

--- a/mimicry/source/Mimicry.pri
+++ b/mimicry/source/Mimicry.pri
@@ -98,7 +98,8 @@ HEADERS += "$$PWD/Mimicry.h" \
            "$$PWD/Mimicry/mi_xmshreader.h" \
            "$$PWD/Mimicry/mi_xmshwriter.h" \
            "$$PWD/Mimicry/mi_xnvmshreader.h" \
-           "$$PWD/Mimicry/mi_xnvmshwriter.h"
+           "$$PWD/Mimicry/mi_xnvmshwriter.h" \
+           "$$PWD/Mimicry/mi_r3mshreader.h"
 
 SOURCES += "$$PWD/Mimicry/mi_3dbreader.cpp" \
            "$$PWD/Mimicry/mi_3dbwriter.cpp" \
@@ -164,4 +165,5 @@ SOURCES += "$$PWD/Mimicry/mi_3dbreader.cpp" \
            "$$PWD/Mimicry/mi_xmshreader.cpp" \
            "$$PWD/Mimicry/mi_xmshwriter.cpp" \
            "$$PWD/Mimicry/mi_xnvmshreader.cpp" \
-           "$$PWD/Mimicry/mi_xnvmshwriter.cpp"
+           "$$PWD/Mimicry/mi_xnvmshwriter.cpp" \
+           "$$PWD/Mimicry/mi_r3mshreader.cpp"

--- a/mimicry/source/Mimicry.vcproj
+++ b/mimicry/source/Mimicry.vcproj
@@ -694,6 +694,14 @@
 				>
 			</File>
 			<File
+				RelativePath=".\Mimicry\mi_r3mshreader.cpp"
+				>
+			</File>
+			<File
+				RelativePath=".\Mimicry\mi_r3mshreader.h"
+				>
+			</File>
+			<File
 				RelativePath=".\Mimicry\mi_xactreader.cpp"
 				>
 			</File>

--- a/mimicry/source/Mimicry/mi_include_converters.h
+++ b/mimicry/source/Mimicry/mi_include_converters.h
@@ -31,6 +31,7 @@
 #include "mi_xnvmshwriter.h"
 #include "mi_xcomreader.h"
 #include "mi_xcomwriter.h"
+#include "mi_r3mshreader.h"
 #include "mi_genomefile.h"
 #include "mi_genomevolume.h"
 #include "mi_genomematerial.h"

--- a/mimicry/source/Mimicry/mi_r3mshreader.cpp
+++ b/mimicry/source/Mimicry/mi_r3mshreader.cpp
@@ -1,0 +1,141 @@
+#include "mi_include_converters.h"
+
+namespace
+{   
+    mCString ReadString( mCIOStreamBinary & a_streamSource )
+    {
+        return a_streamSource.ReadString( a_streamSource.ReadU16() );
+    }
+}
+
+mEResult mCR3mshReader::ReadR3mshFileData(mCScene & a_sceneDest, mCIOStreamBinary & a_streamSource, SOptions a_Options)
+{
+    a_sceneDest.Clear();
+    mCString const strSceneName = dynamic_cast< mCFileStream * >( &a_streamSource ) ? g_GetFileNameNoExt( dynamic_cast< mCFileStream * >( &a_streamSource )->GetFileName() ) : "";
+    if ( a_streamSource.ReadString( 4 ) != "R3RF" )
+        return MI_ERROR( mCStreamError, EBadFormat, "Invalid .r3msh file." ), mEResult_False;
+    MIU32 uResourceHeaderOffset = a_streamSource.ReadU32();
+    a_streamSource.Skip(36);
+    if (a_streamSource.ReadString(4) != "GMSH" || a_streamSource.ReadU32() != 0x01)
+        return MI_ERROR(mCStreamError, EBadFormat, "Invalid .r3msh file."), mEResult_False;
+    a_streamSource.ReadU32();
+
+    MIU32 uIndicesSize = a_streamSource.ReadU32();
+    if (uIndicesSize % 2 != 0 || (uIndicesSize / 2) % 3 != 0)
+        return MI_ERROR(mCStreamError, EBadFormat, "Invalid .r3msh file."), mEResult_False;
+    a_streamSource.ReadU32();
+
+    mCMesh meshDest;
+    mCNode & nodeDest = a_sceneDest.AddNewNode();
+    mCMultiMaterial & matMultiDest = a_sceneDest.AddNewMultiMaterial();
+    nodeDest.AccessName() = strSceneName;
+    nodeDest.AccessMaterialName() = matMultiDest.AccessName() = "Mtls_" + strSceneName;
+   
+    MIUInt uFaceCount = uIndicesSize / 6;
+    meshDest.SetNumFaces(uFaceCount);
+    mCMaxFace * pFace = meshDest.AccessFaces();
+    /*for (MIUInt u = 0, ue = arrSubMeshFaceCounts.GetCount(); u != ue; ++u)
+        for (MIUInt v = arrSubMeshFaceCounts[u]; v--; (pFace++)->AccessMatID() = u)
+            a_streamSource >> pFace->AccessC() >> pFace->AccessB() >> pFace->AccessA();*/
+    for (MIUInt u = 0, ue = uFaceCount; u != ue; ++u, (pFace++))
+        a_streamSource >> (MIU16 &)pFace->AccessC() >> (MIU16 &)pFace->AccessB() >> (MIU16 &)pFace->AccessA();
+    
+    MIU32 uVerticesSize = a_streamSource.ReadU32();
+    MIU32 uVertexSize = a_streamSource.ReadU32();
+    if (uVerticesSize % uVertexSize != 0)
+        return MI_ERROR(mCStreamError, EBadFormat, "Invalid .r3msh file."), mEResult_False;
+    a_streamSource.ReadU32();
+
+    MIUInt uPositionOffset = MI_DW_INVALID;
+    MIUInt uNormalOffset = MI_DW_INVALID;
+    MIUInt uTexCoordOffset = MI_DW_INVALID;
+    MIUInt uColor1Offset = MI_DW_INVALID;
+    MIUInt uColor2Offset = MI_DW_INVALID;
+    struct SVertexElement  // D3DVERTEXELEMENT9
+    {
+        MIU16 m_u16StreamIndex;
+        MIU16 m_u16Offset;
+        MIU8  m_u8Type;
+        MIU8  m_u8Method;
+        MIU8  m_u8Usage;
+        MIU8  m_u8UsageIndex;
+    };
+    
+    MIUInt uVertexElementsCount = a_streamSource.ReadU32();
+    for (MIUInt u = 0; u != uVertexElementsCount; ++u)
+    {
+        SVertexElement Decl;
+        a_streamSource.Read( &Decl, sizeof( SVertexElement ) );
+        if ( Decl.m_u16StreamIndex != 0 ||
+             Decl.m_u8Method != 0 )
+            continue;
+        else if ( Decl.m_u8Usage == 00 && Decl.m_u8Type == 2 )
+            uPositionOffset = Decl.m_u16Offset;
+        else if ( Decl.m_u8Usage == 03 && Decl.m_u8Type == 2 )
+            uNormalOffset = Decl.m_u16Offset;
+        else if ( Decl.m_u8Usage == 05 && Decl.m_u8Type == 1 && Decl.m_u8UsageIndex == 0 )
+            uTexCoordOffset = Decl.m_u16Offset;
+        else if ( Decl.m_u8Usage == 10 && Decl.m_u8Type == 4 && Decl.m_u8UsageIndex == 0 )
+            uColor1Offset = Decl.m_u16Offset;
+        else if ( Decl.m_u8Usage == 10 && Decl.m_u8Type == 4 && Decl.m_u8UsageIndex == 1 )
+            uColor2Offset = Decl.m_u16Offset;
+    }
+    if ( uPositionOffset == MI_DW_INVALID )
+        return MI_ERROR( mCStreamError, EBadFormat, "Invalid .r3msh file." ), mEResult_False;
+    
+    MIUInt uVertexCount = uVerticesSize / uVertexSize;
+    mCMemoryStream streamVertices;
+    streamVertices.Resize( uVerticesSize );
+    a_streamSource.Read( streamVertices.AccessBuffer(), uVerticesSize );
+    if ( uPositionOffset != MI_DW_INVALID )
+    {
+        streamVertices.Seek( uPositionOffset );
+        meshDest.SetNumVerts( uVertexCount );
+        for ( mCVec3 * pVert = meshDest.AccessVerts(), * pEnd = pVert + uVertexCount; pVert != pEnd; ++pVert, streamVertices.Skip( uVertexSize - sizeof( *pVert ) ) )
+            streamVertices >> *pVert;
+    }
+    if ( uNormalOffset != MI_DW_INVALID )
+    {
+        streamVertices.Seek( uNormalOffset );
+        meshDest.SetNumVNormals( uVertexCount );
+        for ( mCVec3 * pVNormal = meshDest.AccessVNormals(), * pEnd = pVNormal + uVertexCount; pVNormal != pEnd; ++pVNormal, streamVertices.Skip( uVertexSize - sizeof( *pVNormal ) ) )
+            streamVertices >> *pVNormal;
+    }
+    if ( uTexCoordOffset != MI_DW_INVALID )
+    {
+        streamVertices.Seek( uTexCoordOffset );
+        meshDest.SetNumTVerts( uVertexCount );
+        for ( mCVec3 * pTVert = meshDest.AccessTVerts(), * pEnd = pTVert + uVertexCount; pTVert != pEnd; ++pTVert, streamVertices.Skip( uVertexSize - sizeof( MIFloat ) * 2 ) )
+            streamVertices >> pTVert->AccessX() >> pTVert->AccessY();
+    }
+    if ( uColor1Offset != MI_DW_INVALID )
+    {
+        streamVertices.Seek( uColor1Offset + 3 );
+        meshDest.SetHasVertexColors( MITrue );
+        for ( mCColor * pVColor = meshDest.AccessVertexColors(), * pEnd = pVColor + uVertexCount; pVColor != pEnd; ++pVColor, streamVertices.Skip( uVertexSize - sizeof( MIU8 ) ) )
+            pVColor->AccessRed() = pVColor->AccessGreen() = pVColor->AccessBlue() = streamVertices.ReadU8();
+    }
+    if ( uColor2Offset != MI_DW_INVALID )
+    {
+        streamVertices.Seek( uColor2Offset + 3 );
+        meshDest.SetHasVertexColors( MITrue );
+        for ( mCColor * pVColor = meshDest.AccessVertexColors(), * pEnd = pVColor + uVertexCount; pVColor != pEnd; ++pVColor, streamVertices.Skip( uVertexSize - sizeof( MIU8 ) ) )
+            streamVertices >> g_08( pVColor->AccessAlpha() );
+    }
+   
+    if ( meshDest.HasTVFaces() )
+        meshDest.CopyTVFacesFromFaces();
+    if ( meshDest.HasVNFaces() )
+        meshDest.CopyVNFacesFromFaces();
+    meshDest.WeldVertices();
+    mCMaxRisenCoordShifter::GetInstance().ShiftMeshCoords( meshDest );
+    nodeDest.SwapMesh( meshDest );
+    /*if ( mCGenomeMaterial::AccessMaterialLookupHint() )
+        mCGenomeMaterial::LoadRisenMaterials( a_sceneDest );*/
+    if ( a_Options.m_strTextureFileExtension != "" )
+        for ( mCMaterial * pMat = matMultiDest.AccessSubMaterials().AccessBuffer(), * pEnd = pMat + matMultiDest.GetSubMaterials().GetCount(); pMat != pEnd; ( pMat++ )->RemoveEmptyTexMaps() )
+            for ( mCMaterial::EMapType i = mCMaterial::EMapType_Diffuse; i != mCMaterial::EMapType_Count; ++i )
+                g_ReplaceFileExt( pMat->AccessTexMap( i ).AccessTextureFilePath(), a_Options.m_strTextureFileExtension );
+    a_sceneDest.SetName( strSceneName );
+    return mEResult_Ok;
+}

--- a/mimicry/source/Mimicry/mi_r3mshreader.h
+++ b/mimicry/source/Mimicry/mi_r3mshreader.h
@@ -1,0 +1,15 @@
+#ifndef MI_R3MSHREADER_H_INCLUDED
+#define MI_R3MSHREADER_H_INCLUDED
+
+class mCR3mshReader
+{
+public:
+    struct SOptions :
+        public eSConverterOptions
+    {
+    };
+public:
+    static mEResult ReadR3mshFileData(mCScene & a_sceneDest, mCIOStreamBinary & a_streamSource, SOptions a_Options = SOptions());
+};
+
+#endif


### PR DESCRIPTION
Based on Baltrams Risen mCXmshReader included in Rimy3D, i wrote a basic Risen 3 mesh reader.
For now it ignores the eCMeshResource2 class (contains info about materials and submeshes) and simply reads the data stored in ResourceOffsetTable.Data1 block.
